### PR TITLE
fix: makefile, node 20 and README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Makefile for GraphAI demo
+#
+.PHONY: init
+init:
+	yarn global add firebase-tools
+	yarn install
+	cd functions && yarn install
+	@echo in firebase console, add project , choose web, copy config to src/config/project.ts
+	open https://firebase.google.com

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 # Makefile for GraphAI demo
 #
-.PHONY: init
-init:
+## install: Initialize and start firebase
+.PHONY: install
+install:
+	brew install vite
 	yarn global add firebase-tools
 	yarn install
 	cd functions && yarn install
+
+## firebase: Install into firebase
+.PHONY: firebase
 	@echo in firebase console, add project , choose web, copy config to src/config/project.ts
 	open https://firebase.google.com
+
+## serve: run locally
+.PHONY: serve
+serve: install
+	yarn run serve

--- a/README.md
+++ b/README.md
@@ -1,61 +1,98 @@
-# firebase-vue3-startup-kit/GraphAI
+# GraphAI Web Demo Application
 
-## Purpose
+This demonstrates the scale and capacity of GraphAI
+
+## Technology Stack
+
+Based on the firebase-vue3-startup-kit/GraphAI
 
 This is a Start-Up kit for a Firebase web project, which uses Vue3 and firebase 9.
 
 This package includes vite, vue-router, pinia, tailwindcss, prettier, vue-tsc
 
-## Requirements 
+## Requirements
 
 - Node.js version 16 or later.
+- Functions requires node 18
 
 ## Instruction
 
+You can also use the helper `make init` to automate the yarn installations and
+get you to firebase
+
 1. Git clone this repository
-2. Run "yarn global add firebase-tools" to install firebase tools. 
+2. Run "yarn global add firebase-tools" to install firebase tools.
 3. Run "yarn install" once to get necessary node modules.
 4. Run "yarn install" once in the functions directory as well.
-5. Open the firebase console (from https://firebase.google.com) and add a project
-6. From the dashboard of this project, add an app and choose "web" (</>).
-7. From the setting of this app, choose "Config" (in Firebase SDK snippet)
-8. Copy the config file, and paste into src/config/project.ts file.  
-9. Replace the word "fir-vue-startup-kit" in .firebaserc file with your Firebase project name.
-10. Open the firebase console, and create a Cloud Firestore (make it "secure" for now).
-11. Enable Firebase Hosting on the firebase console.
+5. Open the firebase console (from
+   [firebase.google.com](https://firebase.google.com) and add a project
+
+Now you must manually do this or if you are with TNE, they you can go to our
+Demo Firebase application at
+[graphai-web-demo](https://console.firebase.google.com/u/2/project/graphai-web-demo/overview)
+
+1. From the dashboard of this project, add an app such as `graphai-web-demo`
+   choose "web" which has the strange icon `(</>)`.
+1. From the setting of this app, choose "Config" (in Firebase SDK snippet)
+1. Copy the config file, and paste into src/config/project.ts file.
+1. Replace the word "fir-vue-startup-kit" in .firebaserc file with your Firebase
+   project name.
+1. Open the firebase console, and create a Cloud Firestore (make it "secure"
+   for now).
+1. Enable Firebase Hosting on the firebase console.
 
 ## Funcitons
-Because Firebase Functions is very slow in the case of cold start by default setting, this startup-kit is a bit of a custom Firebase functions.
+
+Because Firebase Functions is very slow in the case of cold start by default
+setting, this startup-kit is a bit of a custom Firebase functions.
 
 ### Functions side
- - Functions is invoked using a wrapper function (`exportIfNeeded` function in `functions/src/common/exportifneeded.ts`). It loads only the functions it needs.
- - Functions will start with enough memory. `test` function in `functions/src/wrappers/tests/test.ts` run with 1GB memory.
- - Functions run in a nearby region. In my case it is Japan, so it is set in the Japanese region. Please change it to suit your location.
 
-For this reason, Functions are used in a slightly unusual way. 
-Functions called by the client are written in `src/index.ts` like `exportIfNeeded ("test", "tests/test", exports);`
+- Functions is invoked using a wrapper function (`exportIfNeeded` function in
+  `functions/src/common/exportifneeded.ts`). It loads only the functions it needs.
+- Functions will start with enough memory. `test` function in
+  `functions/src/wrappers/tests/test.ts` run with 1GB memory.
+- Functions run in a nearby region. In my case it is Japan, so it is set in the
+  Japanese region. Please change it to suit your location.
 
-In this case, the client calls test as a function. And when the client call the test Function, the default function in `functions/src/wrappers/tests/test.ts` is called. See this file for more information.
+For this reason, Functions are used in a slightly unusual way. Functions called
+by the client are written in `src/index.ts` like `exportIfNeeded ("test",
+"tests/test", exports);`
 
-###  Vue.js side.
- - The functions settings are in `src/utils/firebase.ts`. By default, it set to call asia-northeast1 (Tokyo) region.
- - All functions put together in `src/utils/functions.ts`. You should add new functions in this file.
+In this case, the client calls test as a function. And when the client call the
+test Function, the default function in `functions/src/wrappers/tests/test.ts` is
+called. See this file for more information.
+
+### Vue.js side
+
+- The functions settings are in `src/utils/firebase.ts`. By default, it set to
+  call asia-northeast1 (Tokyo) region.
+- All functions put together in `src/utils/functions.ts`. You should add new
+  functions in this file.
 
 ### Region
- 
-The region of Functions is set in asia-northeast1(Tokyo). If you change the region, be sure to change both Vue.js in Functions.
+
+The region of Functions is set in asia-northeast1(Tokyo). If you change the
+region, be sure to change both Vue.js in Functions.
 
 ## i18n
- - This startup-kit supports i18n using url path.
- - You can use one Vue file in both `/en/index` and `/jp/index` .
- - Language files are in `src/i18n/` directory.
-    - `en.ts` and `ja.ts` are Language files.
-    - The language file used for the language switching pull-down (select) is `language.ts`. The same file is read from `en.ts` and `ja.ts`. Write in each language.
-    - If you want to add new language, add the language to `index.ts`, add the `{language}.ts`, and add language to `language.ts`.
- - See also `src/router/index.ts` for how to switch languages with url path.
- - You can use the language switching pull-down in `src/components/Languages.vue`. This file needs to read `route.param.lang`, so don't use it in `App.vue` and `Layout.vue`. Other than that, it can be used anywhere.
- - i18n uses `vue-i18n@next`, so please refer to that for details on how to use it.
 
+- This startup-kit supports i18n using url path.
+- You can use one Vue file in both `/en/index` and `/jp/index` .
+- Language files are in `src/i18n/` directory.
+  - `en.ts` and `ja.ts` are Language files.
+  - The language file used for the language switching pull-down (select) is
+    `language.ts`. The same file is read from `en.ts` and `ja.ts`. Write in each
+    language.
+  - If you want to add new language, add the language to `index.ts`, add the
+    `{language}.ts`, and add language to `language.ts`.
+- See also `src/router/index.ts` for how to switch languages with url path.
+- You can use the language switching pull-down in
+  `src/components/Languages.vue`. This file needs to read `route.param.lang`, so
+  don't use it in `App.vue` and `Layout.vue`. Other than that, it can be used
+  anywhere.
+- i18n uses `vue-i18n@next`, so please refer to that for details on how to use
+  it.
 
 ## Available Scripts
 
@@ -63,25 +100,29 @@ In the project directory, you can run:
 
 ### `yarn run serve`
 
-Runs the app in the development mode.<br>
-Open [http://localhost:8080](http://localhost:8080) to view it in the browser.
+Runs the app in the development mode.
+Open
+[http://localhost:8080](http://localhost:8080) to view it in the browser.
 
-The page will reload if you make edits.<br>
-You will also see any lint errors in the console.
+The page will reload if you make edits.
+You will also see any lint errors in
+the console.
 
 ### `yarn run build`
 
-Builds the app for production to the `dist` folder.<br>
-It correctly bundles Vue in production mode and optimizes the build for the best performance.
+Builds the app for production to the `dist` folder.
+It correctly bundles Vue
+in production mode and optimizes the build for the best performance.
 
-The build is minified and the filenames include the hashes.<br>
-Your app is ready to be deployed!
+The build is minified and the filenames include the hashes.
+Your app is
+ready to be deployed!
 
 ### `firebase deploy`
 
-Deploys the app to the Firebase cloud. You need to run "yarn run build" before the deployment.
+Deploys the app to the Firebase cloud. You need to run "yarn run build" before
+the deployment.
 
 ### `yarn run format`
 
 Run Prettier, rewrite code as code formatting.
-

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "18"
+    "node": "20"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/src/config/project.ts
+++ b/src/config/project.ts
@@ -1,0 +1,21 @@
+// Import the functions you need from the SDKs you need
+import { initializeApp } from "firebase/app";
+import { getAnalytics } from "firebase/analytics";
+// TODO: Add SDKs for Firebase products that you want to use
+// https://firebase.google.com/docs/web/setup#available-libraries
+
+// Your web app's Firebase configuration
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+const firebaseConfig = {
+  apiKey: "AIzaSyBI9jxPm-d3pxUw6cQtxk55DhJYfJCrkt8",
+  authDomain: "graphai-web-demo.firebaseapp.com",
+  projectId: "graphai-web-demo",
+  storageBucket: "graphai-web-demo.appspot.com",
+  messagingSenderId: "641612969846",
+  appId: "1:641612969846:web:f40c4728361de0f4876c57",
+  measurementId: "G-VL257S0YH3",
+};
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);


### PR DESCRIPTION
Ok, @isamu I wasn't sure if this is the right format but some quick notes:

1. I updated the README.md top because it didn't explain what GraphAI is and was mainly a copy of the fork
2. I normally have a Makefile which does the setup stuff, I don't know how you work, but `make install` does the first few steps of the setup right up so it brew install vite and does the yarn install
3. On my machine, the yarn install in functions fails because it wants node 18. I updated to node 20 and this seemed to run locally, but see below
4. I got stuck at the step where it says copy the typescript into the ./src/config directory as there is no such directory, are we supposed to make one?
5. The yarn run serve seems to work but load and save don't do anything, I presume these require firebase to run properly?